### PR TITLE
Add zone discovery to async Onkyo integration

### DIFF
--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -238,7 +238,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     def async_onkyo_discover_zones_callback(message):
         """Receive the power status of the available zones on the AVR."""
-        """Returns True when zone discovery is completed."""
         zone, command, _ = message
         if command in ["system-power", "power"]:
             # When we receive the status for a zone, it is available on the AVR
@@ -246,7 +245,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             if zone in zones:
                 _LOGGER.info("Discovered %s on %s, add to active zones", zone, name)
                 active_zones.append(OnkyoAVR(avr, name, sources, zone, max_volume))
-                return False
 
             # When we receive the main status, we don't expect any other zones
             # So add all entities in active_zones and finish zone discovery
@@ -255,6 +253,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                     zone.backfill_state()
                 async_add_entities(active_zones)
                 return True
+        return False
 
     @callback
     def async_onkyo_update_callback(message):
@@ -540,6 +539,7 @@ class OnkyoAVR(MediaPlayerEntity):
         if audio_information == "N/A":
             self._attributes.pop(ATTR_AUDIO_INFORMATION, None)
             return
+
         self._attributes[ATTR_AUDIO_INFORMATION] = {
             name: value
             for name, value in zip(AUDIO_INFORMATION_MAPPING, audio_information)

--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -231,7 +231,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         "async_select_output",
     )
 
-    _LOGGER.debug(f"Provisioning Onkyo AVR device at {host}:{port}")
+    _LOGGER.debug("Provisioning Onkyo AVR device at %s:%d", host, port)
 
     active_zones = []
     zone_discovery_completed = False
@@ -243,14 +243,14 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             # When we receive the status for a zone, it is available on the AVR
             # So we create an entity for the zone and continue discovery
             if zone in zones:
-                _LOGGER.debug(f"Discovered {zone} on {name}, add to active zones")
+                _LOGGER.debug("Discovered %s on %s, add to active zones", zone, name)
                 zone_entity = OnkyoAVR(avr, name, sources, zone, max_volume)
                 active_zones.append(zone_entity)
                 async_add_entities([zone_entity])
 
             # When we receive the main status, we finish zone discovery
             elif zone == "main":
-                _LOGGER.debug(f"Finished zone discovery on {name}")
+                _LOGGER.debug("Finished zone discovery on %s", name)
                 for zone in active_zones:
                     zone.backfill_state()
                 return True
@@ -259,7 +259,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     @callback
     def async_onkyo_update_callback(message):
         """Receive notification from transport that new data exists."""
-        _LOGGER.debug(f"Received update callback from AVR: {message}")
+        _LOGGER.debug("Received update callback from AVR: %s", message)
 
         # Define the zone_discovery_completed variable as non-local
         # This way the variable stays consistent over multiple callbacks

--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -261,7 +261,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         _LOGGER.debug("Received update callback from AVR: %s", message)
 
         _zone, _, _ = message
-        if any(active_zone._zone == _zone for active_zone in active_zones):
+        if any(active_zone.zone == _zone for active_zone in active_zones):
             for zone in active_zones:
                 zone.process_update(message)
         else:
@@ -398,6 +398,11 @@ class OnkyoAVR(MediaPlayerEntity):
         else:
             self._query_avr("muting")
             self._query_avr("selector")
+
+    @property
+    def zone(self):
+        """Return zone string of device."""
+        return self._zone
 
     @property
     def supported_features(self):

--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -40,7 +40,7 @@ CONF_ZONES = "zones"
 
 DEFAULT_NAME = "Onkyo Receiver"
 SUPPORTED_MAX_VOLUME = 90
-ZONES = ["zone2", "zone3", "zone4"]
+ZONES = {"zone2": "Zone 2", "zone3": "Zone 3", "zone4": "Zone 4"}
 
 DEFAULT_SOURCES = {
     "tv": "TV",
@@ -312,7 +312,7 @@ class OnkyoAVR(MediaPlayerEntity):
         """Initialize entity with transport."""
         super().__init__()
         self._avr = avr
-        self._name = f"{name} {zone if zone != 'main' else ''}"
+        self._name = f"{name} {ZONES[zone] if zone != 'main' else ''}"
         self._zone = zone
         self._volume = 0
         self._supports_volume = False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the auto discovery of AVR zones back to the Onkyo integration after switching to local push

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
media_player:
  - platform: onkyo
    host: 10.10.10.10
    name: Amplifier
    max_volume: 75
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Zones are removed from the configuration, because they are now discovered so there's no need to specify them in the configuration

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
